### PR TITLE
Leave toggled items in place

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -44,11 +44,6 @@ $('body').on('click', '.extName', e => {
 
 	cme.setEnabled(id, !wasEnabled, () => {
 		$extension.toggleClass('disabled', wasEnabled);
-		if (wasEnabled) {
-			eul.append($extension);
-		} else {
-			eul.prepend($extension);
-		}
 	})
 }).on('mouseup', '.extName', e => {
 	if (e.which == 3) {


### PR DESCRIPTION
Sometimes I click on the wrong extension by mistake. Finding it again is not easy.

This change leaves the extension in place until the next popup is opened

![toggle in place](https://cloud.githubusercontent.com/assets/1402241/23714304/900cf350-03dd-11e7-8526-eea95a28a814.gif)
